### PR TITLE
9.0-mig-project_duplicate_fix

### DIFF
--- a/project_duplicate_fix/README.rst
+++ b/project_duplicate_fix/README.rst
@@ -1,0 +1,65 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================
+Project Duplicate FIX
+=====================
+Deletes messages of the new project when you duplicate a project.
+
+Installation
+============
+
+To install this module, you need to:
+
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+
+Usage
+=====
+
+To use this module, you need to:
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.adhoc.com.ar/
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "9.0" for example
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* ADHOC SA: `Icon <http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png>`_.
+
+Contributors
+------------
+
+
+Maintainer
+----------
+
+.. image:: http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png
+   :alt: Odoo Community Association
+   :target: https://www.adhoc.com.ar
+
+This module is maintained by the ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/project_duplicate_fix/__openerp__.py
+++ b/project_duplicate_fix/__openerp__.py
@@ -24,10 +24,6 @@
     'category': 'Projects & Services',
     'sequence': 14,
     'summary': '',
-    'description': """
-Project Duplicate FIX
-=====================
-    """,
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
@@ -42,7 +38,7 @@ Project Duplicate FIX
     ],
     'test': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }


### PR DESCRIPTION
Deletes messages of the new project when you duplicate a project.
