### PR TITLE
ADD Adjust activity visibility to match project

### DIFF
--- a/project_task_activity/__openerp__.py
+++ b/project_task_activity/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Project Task Activity",
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.3.0',
     'category': 'Tools',
     'sequence': 14,
     'author':  'ADHOC SA',
@@ -40,7 +40,8 @@ Project Task Activity
         'view/activities_menuitem.xml',
         'view/project_view.xml',
         'view/task_view.xml',
-        'security/ir.model.access.csv'
+        'security/ir.model.access.csv',
+        'security/project_security.xml',
     ],
     'demo': [
     ],

--- a/project_task_activity/security/project_security.xml
+++ b/project_task_activity/security/project_security.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data noupdate="1">
+
+    <record model="ir.rule" id="task_visibility_rule">
+        <field name="name">Project/Activity: employees: public or employee or (followers and following)</field>
+        <field name="model_id" ref="model_project_task_activity"/>
+        <field name="domain_force">[
+        '|',
+            ('project_id.privacy_visibility', 'in', ['public', 'employees']),
+            '|',
+                '&amp;',
+                    ('project_id.privacy_visibility', '=', 'followers'),
+                    ('project_id.message_follower_ids', 'in', [user.partner_id.id]),
+                '|',
+                    ('task_id.message_follower_ids', 'in', [user.partner_id.id]),
+                    # to subscribe check access to the record, follower is not enough at creation
+                    ('user_id', '=', user.id)
+        ]</field>
+        <field name="groups" eval="[(4,ref('base.group_user'))]"/>
+    </record>
+
+    <record model="ir.rule" id="project_manager_all_project_tasks_rule">
+        <field name="name">Project/Activity: project manager: see all</field>
+        <field name="model_id" ref="model_project_task_activity"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Currently all activities are readable by everyone which does not match the expectation set by the rest of the project module. This adds the relevant `ir.rule` entries.