### PR TITLE
[FIX] project_ux: Proper filter the subtasks

### DIFF
--- a/project_ux/__manifest__.py
+++ b/project_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Project UX',
-    'version': '11.0.1.6.0',
+    'version': '11.0.1.6.1',
     'category': 'Project Management',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/project_ux/models/project_project.py
+++ b/project_ux/models/project_project.py
@@ -40,13 +40,13 @@ class ProjectProject(models.Model):
 
     @api.multi
     def copy(self, default=None):
-        tasks = self.task_ids
         project = super(ProjectProject, self).copy(default)
-        # We setting the if the subtask project and the project are the same
-        # the new id of the subtask project and the new project
-        #  for the new tasks
+        # If we have subtasks we need to fix the project of this substasks
+        # manually asigning the new project_id, if not the new subtasks will
+        # refer to the template project
         if self.subtask_project_id == self:
-            (self.tasks - tasks).update({'project_id': project.id})
+            subtasks = self.tasks.filtered('parent_id')
+            subtasks.write({'project_id': project.id})
             project.subtask_project_id = project.id
         return project
 


### PR DESCRIPTION
Formerly when copuy the project we was using a method to filter the subtasks
that was not taking into account the tasks in the original template project
that were in an stage folded or archived. The result of this was that we
were moving the task in folded stage from the template project to the new
project.

To avoid this we filter the subtasks as the one related to the project that
have parent_id.