### PR TITLE
[FIX] project_ux: Proper fix substaks, do not affect project template subtaks

### DIFF
--- a/project_ux/__manifest__.py
+++ b/project_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Project UX',
-    'version': '11.0.1.6.1',
+    'version': '11.0.1.6.2',
     'category': 'Project Management',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/project_ux/models/project_project.py
+++ b/project_ux/models/project_project.py
@@ -45,7 +45,7 @@ class ProjectProject(models.Model):
         # manually asigning the new project_id, if not the new subtasks will
         # refer to the template project
         if self.subtask_project_id == self:
-            subtasks = self.tasks.filtered('parent_id')
+            subtasks = project.tasks.filtered('parent_id')
             subtasks.write({'project_id': project.id})
             project.subtask_project_id = project.id
         return project


### PR DESCRIPTION
I introduce an error in the last change when not only the new project
substasks were fixed, also the project template subtasks were being assigned
to the new project's subtask too by mistake.

This PR fix this, only new project subtasks are related to the new project.