### PR TITLE
[MIG] project_ux: several modifications and make installable

### DIFF
--- a/project_ux/__manifest__.py
+++ b/project_ux/__manifest__.py
@@ -36,7 +36,7 @@
     ],
     'demo': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/project_ux/models/project_task.py
+++ b/project_ux/models/project_task.py
@@ -10,6 +10,7 @@ class ProjectTask(models.Model):
 
     template_task = fields.Boolean(
         copy=False,
+        string="Is task template?"
     )
 
     template_task_id = fields.Many2one(

--- a/project_ux/models/project_task.py
+++ b/project_ux/models/project_task.py
@@ -51,9 +51,8 @@ class ProjectTask(models.Model):
 
     # We overwrite this function because it is not possible to inherit it and
     # we do that calculates only the subtasks that are in the closed stages.
-    @api.multi
     def _compute_subtask_count(self):
-        for task in self:
+        for task in self.filtered(lambda t: isinstance(t.id, int)):
             task.subtask_count = self.search_count(
                 [('id', 'child_of', task.id),
                  ('id', '!=', task.id),

--- a/project_ux/models/project_task.py
+++ b/project_ux/models/project_task.py
@@ -10,7 +10,7 @@ class ProjectTask(models.Model):
 
     template_task = fields.Boolean(
         copy=False,
-        string="Is task template?"
+        string="Is task template?",
     )
 
     template_task_id = fields.Many2one(

--- a/project_ux/views/project_project_views.xml
+++ b/project_ux/views/project_project_views.xml
@@ -19,10 +19,6 @@
             <xpath expr="//notebook//group[@groups='base.group_no_one']" position="attributes">
                 <attribute name="groups"></attribute>
             </xpath>
-            <field name="analytic_account_id" position="replace"/>
-            <field name="sequence" position="before">
-                <field name="analytic_account_id" required="False"/>
-            </field>
              <xpath expr="//notebook//page[1]" position="after">
                 <page string="Project Stages" attrs="{'invisible': [('task_count', '=', 0)]}" name="project_stages">
                     <field name="type_ids"/>

--- a/project_ux/views/project_task_views.xml
+++ b/project_ux/views/project_task_views.xml
@@ -10,7 +10,7 @@
                 <attribute name="attrs">{}</attribute>
             </button>
             <field name="child_ids" position="replace"/>
-            <h1 class="o_row" position="before">
+            <h1 class="d-flex flex-row justify-content-between" position="before">
                 <h2 class="o_row">
                     <field name="template_task_id" placeholder="Task Template" class="oe_edit_only" context="{'default_template_task': 1}"/>
                 </h2>
@@ -28,7 +28,6 @@
                             <field name="project_id"/>
                             <field name="user_id"/>
                             <field name="planned_hours"/>
-                            <field name="remaining_hours" widget="float_time" sum="Remaining Hours" readonly="1"/>
                             <field name="date_deadline" invisible="context.get('deadline_visible',True)"/>
                             <field name="stage_id" options="{'no_create': True, 'no_open': True}"/>
                             <field name="priority" widget="priority"/>
@@ -84,8 +83,8 @@
                 <filter string="Is Sub-Task" name="is_sub_task" domain="[('parent_id','!=', False)]"/>
                 <separator/>
             </filter>
-            <filter name="User" position="before">
-                <filter string="Parent Task" context="{'group_by':'parent_id'}"/>
+            <filter name="user" position="before">
+                <filter string="Parent Task" name="parent_task" context="{'group_by':'parent_id'}"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
- models:
since calculated fields with depends are called on creates, in this case we've solved the issue filtering the record set, to get only objects without 'NewId'.
- views:
we've removed some fields related to some changes made on v 12.0, that make projects not being an analytic account anymore.
also, we've changed some tags that was changed on v 12.0, and added filters 'name' tags, to the ones that haven't got one, as now it is mandatory.