### PR TITLE
[FIX] Access rule now applies correctly to followers

### DIFF
--- a/project_task_activity/__openerp__.py
+++ b/project_task_activity/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Project Task Activity",
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Tools',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/project_task_activity/security/project_security.xml
+++ b/project_task_activity/security/project_security.xml
@@ -11,9 +11,9 @@
             '|',
                 '&amp;',
                     ('project_id.privacy_visibility', '=', 'followers'),
-                    ('project_id.message_follower_ids', 'in', [user.partner_id.id]),
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
-                    ('task_id.message_follower_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
                     # to subscribe check access to the record, follower is not enough at creation
                     ('user_id', '=', user.id)
         ]</field>


### PR DESCRIPTION
Access rule for employees didn't work properly. In case related project _privacy_policy_ field value were _followers_ rule didn't apply; _partner_id_ field of message_partner_ids is not accesible from ir.rule, made a new many2man2 computed field related to following partners in order to apply the rule (also rewrited).