### PR TITLE
[IMP] project_ux: add placeholder to task_state stage field

### DIFF
--- a/project_ux/__manifest__.py
+++ b/project_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Project UX",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.1.0",
     "category": "Project Management",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/project_ux/i18n/project_ux.pot
+++ b/project_ux/i18n/project_ux.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 13:35+0000\n"
-"PO-Revision-Date: 2026-05-08 13:35+0000\n"
+"POT-Creation-Date: 2026-06-29 14:39+0000\n"
+"PO-Revision-Date: 2026-06-29 14:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -62,6 +62,11 @@ msgstr ""
 #. module: project_ux
 #: model:ir.model,name:project_ux.model_project_project
 msgid "Project"
+msgstr ""
+
+#. module: project_ux
+#: model_terms:ir.ui.view,arch_db:project_ux.task_type_edit_inherited
+msgid "Select a state..."
 msgstr ""
 
 #. module: project_ux

--- a/project_ux/views/project_task_type_views.xml
+++ b/project_ux/views/project_task_type_views.xml
@@ -10,7 +10,7 @@
                 <label for="state_change"/>
                 <div class="o_row">
                     <field name="state_change"/>
-                    <field name="task_state" invisible='state_change == False'/>
+                    <field name="task_state" invisible='state_change == False' placeholder="Select a state..."/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
## What

Adds a `placeholder` ("Select a state...") to the `task_state` field on the
project stage form (`project.task.type`), shown next to the `state_change`
checkbox.

## Why

When `state_change` is checked, `task_state` rendered as an empty, borderless
selection box with no placeholder. Users did not realize it was an editable
field until hovering over it — the empty state offered no affordance. Reported
during a usability session.

## How

View-only change: add `placeholder` to the existing `<field name="task_state">`
in `project_task_type_views.xml`. The web Selection widget renders the
placeholder while the field is empty. No Python/model changes.

## Test plan

1. Projects → Configuration → Task Stages → open or create a stage.
2. Check **State Change**.
3. The `task_state` field now shows "Select a state..." while empty (previously
   it looked blank/invisible until hover).
4. Selecting a state still works; the constraint requiring a state when
   `state_change` is on is unchanged.

## Notes

- View-only change → suggested merge policy: `nobump` (manifest minor already
  set to 19.0.2.1.0).
- A companion change for the core `ModelFieldSelector` empty-state affordance
  (same usability report) will be submitted separately in `base_ux`.

Internal task: 69981
